### PR TITLE
Added Laravel 8 models namespace support

### DIFF
--- a/src/Commands/SeedMake.php
+++ b/src/Commands/SeedMake.php
@@ -169,6 +169,13 @@ class SeedMake extends Command
     {
         $model = $this->option("model");
         $model = is_string($model) ? $model : "";
+        
+        $laravelVersion = (int) app()->version();
+
+        if($laravelVersion === 8)
+        {
+            return "App\\Models\\$model";
+        }
 
         return "App\\$model";
     }


### PR DESCRIPTION
Hi,

since this package now supports Laravel 8, as you know in Laravel 8 models are now in App\Models directory. so this PR add check if Laravel version is 8 then return App\Models\$model namespace if not then App\$model.